### PR TITLE
Support pysesame3 v0.4.0

### DIFF
--- a/subscribe.py
+++ b/subscribe.py
@@ -3,23 +3,19 @@ from datetime import datetime
 from pprint import pprint
 
 from pysesame3.auth import WebAPIAuth, CognitoAuth
-from pysesame3.lock import CHSesame2
+from pysesame3.chsesame2 import CHSesame2, CHSesame2ShadowStatus
 from pysesame3.cloud import SesameCloud
 from pysesame3.helper import CHSesame2MechStatus
 
-def post(client, userdata, message):
-    shadow = json.loads(message.payload)
-    status = CHSesame2MechStatus(rawdata=shadow["state"]["reported"]["mechst"])
+def post(device, status):
     obj = {
         "timestamp": datetime.now().isoformat(timespec="seconds"),
         "device_id": os.getenv("SESAME_UUID"),
-        "locked": status.isInLockRange(),
+        "locked": True if device.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm else False
         "position": status.getPosition(),
         "target": status.getTarget(),
     }
     pprint(obj)
-    if abs(obj["target"] - obj["position"]) > 45:
-        return
 
     url = os.getenv("GET_URL")
     if url:


### PR DESCRIPTION
Thank you for using `pysesame3` and for publishing a great example of its use!

I had noticed that the version of `pysesame3` was not fixed in this docker image, and I feared that someday `pysesame3` would break this image when it made a new release containing breaking changes.

And, the time has come. 😥 I am really sorry, but please kindly take a look at [the changelog](https://github.com/mochipon/pysesame3/releases/tag/v0.4.0).

This PR is for suggesting two changes to support the new version of `pysesame3` that has just been released.

1. Changed callback arguments
2. Removed workaround to avoid unnecessary posts
    - From this release, the callback will be executed only if the status is definitely changed (ref. [chsesame2.py#L98](https://github.com/mochipon/pysesame3/blob/2f1290df2ebc5dda7f728c53a6770286b40887af/pysesame3/chsesame2.py#L98)), so I believe that it is okay to remove this workaround.